### PR TITLE
Add theme toggle

### DIFF
--- a/APR.html
+++ b/APR.html
@@ -48,6 +48,19 @@
             --nav-hover-bg: var(--color-primary-accent-generic);
             --nav-hover-text: var(--color-background); /* Dark text on hover */
         }
+
+        body.light-mode {
+            --color-background: #ffffff;
+            --color-surface: #f4f4f4;
+            --color-surface-variant: #e0e0e0;
+            --color-surface-hover: #d5d5d5;
+            --color-text-primary: #1a1d21;
+            --color-text-secondary: #333333;
+            --color-border: #cccccc;
+            --color-shadow: rgba(0,0,0,0.2);
+            --nav-text: #000000;
+            --nav-hover-text: var(--color-background);
+        }
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body {
             font-family: var(--font-main); line-height: 1.6; background-color: var(--color-background);
@@ -79,6 +92,15 @@
         .menu-toggle {
             display: none; background: none; border: none; color: var(--nav-text);
             font-size: 24px; cursor: pointer; padding: 10px 15px;
+        }
+
+        .theme-toggle {
+            color: var(--nav-text);
+            background: none;
+            border: none;
+            font-size: 20px;
+            padding: 10px 15px;
+            cursor: pointer;
         }
         .page-container { flex: 1; padding: 0 20px; width: 100%; margin: 20px auto; }
         .page-header { text-align: center; margin-bottom: 30px; }
@@ -291,6 +313,9 @@
                 <li><a href="BWT.html">Geography Case Studies</a></li>
             </ul>
         </div>
+        <button class="theme-toggle" aria-label="Toggle theme">
+            <i class="fas fa-sun"></i>
+        </button>
         <button class="menu-toggle" aria-label="Toggle menu" aria-expanded="false">
             <i class="fas fa-bars"></i>
         </button>
@@ -347,6 +372,7 @@
     &copy; 2025 Actiari Study Tools. All rights reserved. | <a href="https://github.com/actiari">GitHub</a>
     </footer>
 
+    <script src="theme-toggle.js"></script>
     <script>
     // Hamburger Menu Toggle & Active Nav Link
     document.addEventListener('DOMContentLoaded', function() {

--- a/BWT.html
+++ b/BWT.html
@@ -70,6 +70,19 @@
             --accordion-open-header-text: var(--color-background);
         }
 
+        body.light-mode {
+            --color-background: #ffffff;
+            --color-surface: #f4f4f4;
+            --color-surface-variant: #e0e0e0;
+            --color-surface-hover: #d5d5d5;
+            --color-text-primary: #1a1d21;
+            --color-text-secondary: #333333;
+            --color-border: #cccccc;
+            --color-shadow: rgba(0,0,0,0.2);
+            --nav-text: #000000;
+            --nav-hover-text: var(--color-background);
+        }
+
         * { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
@@ -190,6 +203,15 @@
         .menu-toggle {
             display: none; background: none; border: none; color: var(--nav-text);
             font-size: 24px; cursor: pointer; padding: 10px 15px;
+        }
+
+        .theme-toggle {
+            color: var(--nav-text);
+            background: none;
+            border: none;
+            font-size: 20px;
+            padding: 10px 15px;
+            cursor: pointer;
         }
         /* Responsive Nav */
         @media screen and (min-width: 993px) {
@@ -488,6 +510,9 @@
             <li><a href="BWT.html" class="active-nav-link">Geography Case Studies</a></li> <!-- Example active link -->
         </ul>
     </div>
+    <button class="theme-toggle" aria-label="Toggle theme">
+        <i class="fas fa-sun"></i>
+    </button>
     <button class="menu-toggle" aria-label="Toggle menu" aria-expanded="false">
         <i class="fas fa-bars"></i>
     </button>
@@ -756,6 +781,7 @@
     </footer>
 </div>
 
+<script src="theme-toggle.js"></script>
 <script>
     // Navigation Script
     document.addEventListener('DOMContentLoaded', function() {

--- a/SPBE.html
+++ b/SPBE.html
@@ -33,6 +33,19 @@
       --warning: #fbbc05; /* Yellow from style_source english */
       --danger: #ea4335;  /* Red from style_source chemistry */
     }
+
+    body.light-mode {
+      --color-background: #ffffff;
+      --color-surface: #f4f4f4;
+      --color-surface-variant: #e0e0e0;
+      --color-surface-hover: #d5d5d5;
+      --color-text-primary: #1a1d21;
+      --color-text-secondary: #333333;
+      --color-border: #cccccc;
+      --color-shadow: rgba(0,0,0,0.2);
+      --nav-text: #000000;
+      --nav-hover-text: var(--color-background);
+    }
     
     * {
       box-sizing: border-box;
@@ -105,6 +118,15 @@
       font-size: 24px;
       cursor: pointer;
       padding: 10px 15px; /* Matched style_source */
+    }
+
+    .theme-toggle {
+      color: var(--nav-text);
+      background: none;
+      border: none;
+      font-size: 20px;
+      padding: 10px 15px;
+      cursor: pointer;
     }
     
     #app-container {
@@ -776,6 +798,9 @@
       <li><a href="SPBE.html">Geography Flashcards</a></li>
       <li><a href="BWT.html">Geography Case Studies</a></li>
     </ul>
+    <button class="theme-toggle" aria-label="Toggle theme">
+        <i class="fas fa-sun"></i>
+    </button>
   </div>
 
   <script>
@@ -817,7 +842,8 @@
   <footer>
     &copy; 2025 Actiari Study Tools. All rights reserved. | <a href="https://github.com/actiari">GitHub</a>
   </footer>
-  
+
+  <script src="theme-toggle.js"></script>
   <script src="https://unpkg.com/react@17/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -39,6 +39,19 @@
       --nav-hover-text: var(--color-background); /* Dark text for nav link hover */
     }
 
+    body.light-mode {
+      --color-background: #ffffff;
+      --color-surface: #f4f4f4;
+      --color-surface-variant: #e0e0e0;
+      --color-surface-hover: #d5d5d5;
+      --color-text-primary: #1a1d21;
+      --color-text-secondary: #333333;
+      --color-border: #cccccc;
+      --color-shadow: rgba(0,0,0,0.2);
+      --nav-text: #000000;
+      --nav-hover-text: var(--color-background);
+    }
+
     /* Base styles */
     * {
       box-sizing: border-box;
@@ -115,6 +128,15 @@
       background: none;
       border: none;
       font-size: 24px;
+      padding: 10px 15px;
+      cursor: pointer;
+    }
+
+    .theme-toggle {
+      color: var(--nav-text);
+      background: none;
+      border: none;
+      font-size: 20px;
       padding: 10px 15px;
       cursor: pointer;
     }
@@ -354,6 +376,9 @@
           <li><a href="BWT.html">Geography Case Studies</a></li>
         </ul>
     </div>
+    <button class="theme-toggle" aria-label="Toggle theme">
+        <i class="fas fa-sun"></i>
+    </button>
     <button class="menu-toggle" aria-label="Toggle menu" aria-expanded="false">
         <i class="fas fa-bars"></i>
     </button>
@@ -413,6 +438,7 @@
     &copy; 2025 Actiari Study Tools. All rights reserved. | <a href="https://github.com/actiari">GitHub</a>
   </footer>
 
+  <script src="theme-toggle.js"></script>
   <script>
 document.addEventListener('DOMContentLoaded', function() {
   const menuToggle = document.querySelector('.menu-toggle');

--- a/theme-toggle.js
+++ b/theme-toggle.js
@@ -1,0 +1,25 @@
+function applyTheme(mode) {
+  const button = document.querySelector('.theme-toggle');
+  if (!button) return;
+  if (mode === 'light') {
+    document.body.classList.add('light-mode');
+    button.innerHTML = '<i class="fas fa-moon"></i>';
+  } else {
+    document.body.classList.remove('light-mode');
+    button.innerHTML = '<i class="fas fa-sun"></i>';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const saved = localStorage.getItem('theme');
+  applyTheme(saved === 'light' ? 'light' : 'dark');
+  const button = document.querySelector('.theme-toggle');
+  if (button) {
+    button.addEventListener('click', () => {
+      const isLight = !document.body.classList.contains('light-mode');
+      const newMode = isLight ? 'light' : 'dark';
+      applyTheme(newMode);
+      localStorage.setItem('theme', newMode);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- introduce a reusable `theme-toggle.js` script to switch between dark and light modes
- add light-mode variables and theme toggle button in navigation on major pages
- include the new script in each page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a2d18850832bb0ac9dc8a758ea93