### PR TITLE
Add Brain Dump single page app

### DIFF
--- a/brain-dump/history.html
+++ b/brain-dump/history.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Brain Dump History</title>
+  <link rel="icon" type="image/x-icon" href="../Miscellaneous/Main Favicon.ico">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body{background:#1a1d21;color:#e8eaed;font-family:'Inter',sans-serif;padding:1rem;}
+    a{color:#00b8d4;}
+    ul{list-style:none;padding:0;}
+    li{margin-bottom:0.5rem;}
+    button{margin-left:0.5rem;}
+  </style>
+</head>
+<body>
+  <h1>Session History</h1>
+  <ul id="historyList"></ul>
+  <p><a href="index.html">Back</a></p>
+  <script src="https://unpkg.com/idb-keyval@6/dist/idb-keyval.iife.js"></script>
+  <script src="js/app.js"></script>
+  <script>document.addEventListener('DOMContentLoaded',renderHistory);</script>
+</body>
+</html>

--- a/brain-dump/index.html
+++ b/brain-dump/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Brain Dump</title>
+  <link rel="icon" type="image/x-icon" href="../Miscellaneous/Main Favicon.ico">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+  <style>
+    :root {
+      --color-background: #1a1d21;
+      --color-surface: #252930;
+      --color-surface-variant: #31363f;
+      --color-surface-hover: #3c424c;
+      --color-primary-accent-generic: #00b8d4;
+      --color-text-primary: #e8eaed;
+      --color-text-secondary: #b0b3b8;
+      --color-border: #40454c;
+      --color-shadow: rgba(0,0,0,0.3);
+      --font-main: 'Inter', sans-serif;
+      --border-radius: 8px;
+    }
+    body {
+      margin:0;
+      font-family: var(--font-main);
+      background: var(--color-background);
+      color: var(--color-text-primary);
+      display:flex;
+      flex-direction:column;
+      min-height:100vh;
+    }
+    header {
+      display:flex;
+      gap:1rem;
+      padding:0.5rem 1rem;
+      background:var(--color-surface);
+      align-items:center;
+      height:64px;
+    }
+    main {
+      flex:1;
+      display:flex;
+      gap:1rem;
+      padding:1rem;
+    }
+    textarea {
+      flex:1;
+      min-height:300px;
+      resize:none;
+      padding:0.5rem;
+      border-radius:var(--border-radius);
+      border:1px solid var(--color-border);
+      background:var(--color-surface);
+      color:var(--color-text-primary);
+    }
+    #notesPane {
+      flex:1;
+      border:1px solid var(--color-border);
+      border-radius:var(--border-radius);
+      padding:0.5rem;
+      background:var(--color-surface);
+      overflow:auto;
+      display:none;
+    }
+    footer {
+      display:flex;
+      justify-content:space-between;
+      align-items:center;
+      padding:0.5rem 1rem;
+      background:var(--color-surface-variant);
+      position:fixed;
+      bottom:0;
+      width:100%;
+      height:40px;
+      color:var(--color-text-primary);
+      font-size:0.9rem;
+    }
+    [hidden]{display:none!important;}
+    .badge{padding:0.2rem 0.5rem;background:var(--color-surface-hover);border-radius:var(--border-radius);}
+  </style>
+</head>
+<body>
+  <header>
+    <label for="topicInput" class="visually-hidden">Topic</label>
+    <input id="topicInput" type="text" placeholder="Topic" aria-label="Topic">
+    <label for="durationSelect" class="visually-hidden">Duration</label>
+    <select id="durationSelect" aria-label="Duration in minutes">
+      <!-- options inserted by JS -->
+    </select>
+    <button id="startBtn">Start</button>
+    <button id="resetBtn" hidden>Reset</button>
+    <a href="history.html" style="margin-left:auto;color:var(--color-primary-accent-generic);">History</a>
+  </header>
+  <main>
+    <textarea id="dumpBox" aria-label="Your recall"></textarea>
+    <div id="notesPane" tabindex="0" aria-label="Reference notes"></div>
+  </main>
+  <footer>
+    <span id="timer" aria-live="polite">00:00</span>
+    <span id="saveBadge" class="badge">Autosaved</span>
+    <button id="completeBtn">Mark Complete</button>
+  </footer>
+  <script src="https://unpkg.com/idb-keyval@6/dist/idb-keyval.iife.js"></script>
+  <script src="https://unpkg.com/uuid@9.0.0/dist/umd/uuidv9.min.js"></script>
+  <script src="js/app.js"></script>
+  <script>
+    if('serviceWorker' in navigator){
+      navigator.serviceWorker.register('sw.js');
+    }
+  </script>
+</body>
+</html>

--- a/brain-dump/js/app.js
+++ b/brain-dump/js/app.js
@@ -1,0 +1,176 @@
+const store = idbKeyval.createStore('brainDump-db', 'sessions');
+let countdownTimer = null;
+let autosaveTimer = null;
+let startTime = 0;
+let durationSec = 0;
+let draft = null;
+let tags = [];
+
+function initUI() {
+  const select = document.getElementById('durationSelect');
+  for (let i = 1; i <= 20; i++) {
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = `${i} min`;
+    if (i === 5) opt.selected = true;
+    select.appendChild(opt);
+  }
+  document.getElementById('startBtn').addEventListener('click', startSession);
+  document.getElementById('resetBtn').addEventListener('click', resetSession);
+  document.getElementById('completeBtn').addEventListener('click', saveFinalSession);
+  const dumpBox = document.getElementById('dumpBox');
+  dumpBox.addEventListener('input', () => {
+    dumpBox.style.height = 'auto';
+    dumpBox.style.height = dumpBox.scrollHeight + 'px';
+  });
+  document.addEventListener('keydown', e => {
+    if (e.ctrlKey && e.key === 'Enter') {
+      endSession();
+    } else if (e.key.toLowerCase() === 'm') {
+      markSelectionMissed();
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initUI);
+
+function startSession() {
+  const topic = document.getElementById('topicInput').value.trim() || 'Untitled';
+  durationSec = parseInt(document.getElementById('durationSelect').value, 10) * 60;
+  startTime = Date.now();
+  draft = {
+    id: uuidv9(),
+    topic,
+    dateISO: new Date().toISOString(),
+    durationSec,
+    content: '',
+    notes: '',
+    tags: []
+  };
+  tags = draft.tags;
+  document.getElementById('dumpBox').value = '';
+  document.getElementById('dumpBox').readOnly = false;
+  document.getElementById('dumpBox').focus();
+  document.getElementById('notesPane').style.display = 'none';
+  document.getElementById('startBtn').hidden = true;
+  document.getElementById('resetBtn').hidden = false;
+
+  tickTimer();
+  countdownTimer = setInterval(tickTimer, 250);
+  autosaveTimer = setInterval(autosaveTick, 3000);
+}
+
+function resetSession() {
+  clearInterval(countdownTimer);
+  clearInterval(autosaveTimer);
+  countdownTimer = null;
+  autosaveTimer = null;
+  startTime = 0;
+  durationSec = 0;
+  draft = null;
+  document.getElementById('timer').textContent = '00:00';
+  document.getElementById('dumpBox').value = '';
+  document.getElementById('dumpBox').readOnly = false;
+  document.getElementById('notesPane').style.display = 'none';
+  document.getElementById('startBtn').hidden = false;
+  document.getElementById('resetBtn').hidden = true;
+  idbKeyval.del('draft', store);
+}
+
+function tickTimer() {
+  const elapsed = Math.floor((Date.now() - startTime) / 1000);
+  const remain = Math.max(durationSec - elapsed, 0);
+  const mm = String(Math.floor(remain / 60)).padStart(2, '0');
+  const ss = String(remain % 60).padStart(2, '0');
+  document.getElementById('timer').textContent = `${mm}:${ss}`;
+  if (remain === 0) {
+    endSession();
+  }
+}
+
+function autosaveTick() {
+  if (!draft) return;
+  draft.content = document.getElementById('dumpBox').value;
+  idbKeyval.set('draft', draft, store).then(() => {
+    document.getElementById('saveBadge').textContent = 'Autosaved';
+  });
+}
+
+function endSession() {
+  if (!draft) return;
+  clearInterval(countdownTimer);
+  clearInterval(autosaveTimer);
+  countdownTimer = null;
+  autosaveTimer = null;
+  document.getElementById('dumpBox').readOnly = true;
+  getNotes(draft.topic).then(n => {
+    draft.notes = n;
+    document.getElementById('notesPane').innerText = n;
+    document.getElementById('notesPane').style.display = 'block';
+  });
+}
+
+function getNotes(topic) {
+  return Promise.resolve(`Example notes for ${topic}`);
+}
+
+function markSelectionMissed() {
+  const sel = window.getSelection();
+  const text = sel ? sel.toString().trim() : '';
+  if (!text) return;
+  tags.push(text);
+  draft.tags = tags;
+  if (sel.rangeCount) {
+    const range = sel.getRangeAt(0);
+    const mark = document.createElement('mark');
+    range.surroundContents(mark);
+    sel.removeAllRanges();
+  }
+}
+
+function saveFinalSession() {
+  if (!draft) return;
+  autosaveTick();
+  idbKeyval.set(draft.id, draft, store).then(() => {
+    idbKeyval.del('draft', store);
+    document.getElementById('saveBadge').textContent = `Saved (#${draft.id})`;
+  });
+}
+
+async function renderHistory() {
+  const listEl = document.getElementById('historyList');
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  const keys = await idbKeyval.keys(store);
+  for (const key of keys) {
+    if (key === 'draft') continue;
+    const session = await idbKeyval.get(key, store);
+    const li = document.createElement('li');
+    const missed = session.tags.length;
+    const total = session.notes.split(/\s+/).length;
+    li.textContent = `${session.dateISO.split('T')[0]} | ${session.topic} | ${missed}/${total}`;
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'Delete';
+    delBtn.addEventListener('click', () => {
+      idbKeyval.del(key, store).then(renderHistory);
+    });
+    const expBtn = document.createElement('button');
+    expBtn.textContent = 'Export';
+    expBtn.addEventListener('click', () => exportMarkdown(key));
+    li.append(' ', delBtn, ' ', expBtn);
+    listEl.appendChild(li);
+  }
+}
+
+async function exportMarkdown(id) {
+  const session = await idbKeyval.get(id, store);
+  if (!session) return;
+  const md = `# ${session.topic}\n\n${session.content}\n\n---\n${session.notes}`;
+  const blob = new Blob([md], {type:'text/markdown'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${session.topic}.md`;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/brain-dump/sw.js
+++ b/brain-dump/sw.js
@@ -1,0 +1,18 @@
+const CACHE_NAME = 'brain-dump-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './js/app.js'
+]; // add additional assets if needed
+self.addEventListener('install', e => {
+  self.skipWaiting();
+  e.waitUntil(caches.open(CACHE_NAME).then(c => c.addAll(ASSETS)));
+});
+self.addEventListener('activate', e => {
+  clients.claim();
+});
+self.addEventListener('fetch', e => {
+  e.respondWith(
+    caches.match(e.request).then(r => r || fetch(e.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add Brain Dump study session app under `brain-dump/`
- implement timer, autosave to IndexedDB and marking missed items
- include a simple history page and service worker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a70e3440832b82d6a5a0a01fc503