### PR TITLE
Improve Brain Dump with duration tracking and downloads

### DIFF
--- a/brain-dump/index.html
+++ b/brain-dump/index.html
@@ -94,13 +94,14 @@
   </header>
 
   <main>
-    <textarea id="dumpBox" aria-label="Your recall"></textarea>
+    <textarea id="dumpBox" aria-label="Your recall" placeholder="Type your thoughts here..."></textarea>
     <div id="notesPane" tabindex="0" aria-label="Reference notes"></div>
   </main>
   <footer>
     <span id="timer" aria-live="polite">00:00</span>
     <span id="saveBadge" class="badge">Autosaved</span>
     <button id="completeBtn">Mark Complete</button>
+    <button id="downloadBtn" hidden>Download</button>
   </footer>
   <script src="https://unpkg.com/idb-keyval@6/dist/idb-keyval.iife.js"></script>
   <script src="https://unpkg.com/uuid@9.0.0/dist/umd/uuidv9.min.js"></script>

--- a/brain-dump/js/app.js
+++ b/brain-dump/js/app.js
@@ -2,9 +2,16 @@ const store = idbKeyval.createStore('brainDump-db', 'sessions');
 let countdownTimer = null;
 let autosaveTimer = null;
 let startTime = 0;
-let durationSec = 0;
+let durationSec = 0; // planned session length
+let actualDuration = 0; // actual duration once session ends
 let draft = null;
 let tags = [];
+
+function formatDuration(sec){
+  const m = Math.floor(sec/60);
+  const s = sec % 60;
+  return `${m}:${String(s).padStart(2,'0')}`;
+}
 
 function initUI() {
   const select = document.getElementById('durationSelect');
@@ -18,6 +25,7 @@ function initUI() {
   document.getElementById('startBtn').addEventListener('click', startSession);
   document.getElementById('resetBtn').addEventListener('click', resetSession);
   document.getElementById('completeBtn').addEventListener('click', saveFinalSession);
+  document.getElementById('downloadBtn').addEventListener('click', downloadCurrent);
   const dumpBox = document.getElementById('dumpBox');
   dumpBox.addEventListener('input', () => {
     dumpBox.style.height = 'auto';
@@ -38,6 +46,7 @@ function startSession() {
   const topic = document.getElementById('topicInput').value.trim() || 'Untitled';
   durationSec = parseInt(document.getElementById('durationSelect').value, 10) * 60;
   startTime = Date.now();
+  actualDuration = 0;
   draft = {
     id: uuidv9(),
     topic,
@@ -54,6 +63,7 @@ function startSession() {
   document.getElementById('notesPane').style.display = 'none';
   document.getElementById('startBtn').hidden = true;
   document.getElementById('resetBtn').hidden = false;
+  document.getElementById('downloadBtn').hidden = true;
 
   tickTimer();
   countdownTimer = setInterval(tickTimer, 250);
@@ -74,15 +84,14 @@ function resetSession() {
   document.getElementById('notesPane').style.display = 'none';
   document.getElementById('startBtn').hidden = false;
   document.getElementById('resetBtn').hidden = true;
+  document.getElementById('downloadBtn').hidden = true;
   idbKeyval.del('draft', store);
 }
 
 function tickTimer() {
   const elapsed = Math.floor((Date.now() - startTime) / 1000);
   const remain = Math.max(durationSec - elapsed, 0);
-  const mm = String(Math.floor(remain / 60)).padStart(2, '0');
-  const ss = String(remain % 60).padStart(2, '0');
-  document.getElementById('timer').textContent = `${mm}:${ss}`;
+  document.getElementById('timer').textContent = formatDuration(remain);
   if (remain === 0) {
     endSession();
   }
@@ -102,11 +111,13 @@ function endSession() {
   clearInterval(autosaveTimer);
   countdownTimer = null;
   autosaveTimer = null;
+  actualDuration = Math.floor((Date.now() - startTime) / 1000);
   document.getElementById('dumpBox').readOnly = true;
   getNotes(draft.topic).then(n => {
     draft.notes = n;
     document.getElementById('notesPane').innerText = n;
     document.getElementById('notesPane').style.display = 'block';
+    document.getElementById('downloadBtn').hidden = false;
   });
 }
 
@@ -131,6 +142,7 @@ function markSelectionMissed() {
 function saveFinalSession() {
   if (!draft) return;
   autosaveTick();
+  draft.actualDurationSec = actualDuration;
   idbKeyval.set(draft.id, draft, store).then(() => {
     idbKeyval.del('draft', store);
     document.getElementById('saveBadge').textContent = `Saved (#${draft.id})`;
@@ -148,7 +160,8 @@ async function renderHistory() {
     const li = document.createElement('li');
     const missed = session.tags.length;
     const total = session.notes.split(/\s+/).length;
-    li.textContent = `${session.dateISO.split('T')[0]} | ${session.topic} | ${missed}/${total}`;
+    const dur = formatDuration(session.actualDurationSec || session.durationSec);
+    li.textContent = `${session.dateISO.split('T')[0]} | ${session.topic} | ${dur} | ${missed}/${total}`;
     const delBtn = document.createElement('button');
     delBtn.textContent = 'Delete';
     delBtn.addEventListener('click', () => {
@@ -171,6 +184,19 @@ async function exportMarkdown(id) {
   const a = document.createElement('a');
   a.href = url;
   a.download = `${session.topic}.md`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function downloadCurrent(){
+  if(!draft) return;
+  autosaveTick();
+  const md = `# ${draft.topic}\n\n${draft.content}\n\n---\n${draft.notes}`;
+  const blob = new Blob([md], {type:'text/markdown'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${draft.topic}.md`;
   a.click();
   URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
## Summary
- enhance brain dump session UI with a Download button
- implement duration formatting and tracking
- show session duration in history
- allow export of current session

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ab46fbc0832b9f5bb2f19b4bf491